### PR TITLE
Updated Solution to v3.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Change Log
+ All notable changes to this project will be documented in this file.
+ 
+ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.2] - 2019-12-18
+
+### Added
+- Backward-compatible to v3.0.0
+- Includes all v3.0.1 changes
+- Do NOT upgrade from v3.0.1 to v3.2
+
+## [3.0.1] - 2019-11-29
+
+### Added
+- Uses SSM Parameters to retrieve the latest HVM x86_64 AMI
+- Block public access to 2 buckets created for demo
+- CLFullAccessUserRole replaces CognitoAuthorizedRole. It is associated with the Admin group. Initial user is placed in this group.
+- CLReadOnlyAccessRole is added. It provides read-only access to users in UserPoolGroupROAccess. This is the default role for Authenticated users in the pool.
+
+### Updated
+- Nodejs8.10 to Nodejs12.x Lambda run time.
+- Updated license to Apache License version 2.0
+- Corrected Master_Role environmental variable in spoke template to MASTER_ROLE
+- Updated demo EC2 instance to T3.MICRO
+- Updated Nodejs deprecated buffer() to buffer.from()
+- Removed python solution-helper from spoke template and replaced with the Nodejs version used by primary.
+- Updated NOTICE.txt for 3rd party modules
+- Replaced istanbul (deprecated) with nyc
+- ElasticSearch version moved to a mapping parameter
+- ElasticSearch cluster mappings consolidated under ElasticSearch for clarity/usability
+- Tightened security on IAM roles to specific methods and resources
+
+### Removed
+- Unreferenced SolutionHelperRole in demo template
+- Unreferenced S3 bucket mapping in demo template
+- AMIInfo lookup Lambda
+- CognitoUnAuthorizedRole / unauthenticated Cognito access
+ 
+## [0.0.1] - 2019-09-09
+### Added
+- CHANGELOG template file to fix new pipeline standards
+
+### Updated
+- updated buildspec.yml to meet new pipeline build standards
+- updated build-s3-dist.sh to meet new pipeline build standards
+- updated run-unit-tests.sh for correct references to folders
+- updated cloudformation templates to include a bucket for S3 access logs
+- updated cloudformation template with correct lambda function environment variable key names

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,32 +1,177 @@
-Amazon Software License
-This Amazon Software License (“License”) governs your use, reproduction, and distribution of the accompanying software as specified below.
-1. Definitions
-“Licensor” means any person or entity that distributes its Work.
 
-“Software” means the original work of authorship made available under this License.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-“Work” means the Software and any additions to or derivative works of the Software that are made available under this License.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-The terms “reproduce,” “reproduction,” “derivative works,” and “distribution” have the meaning as provided under U.S. copyright law; provided, however, that for the purposes of this License, derivative works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work.
+   1. Definitions.
 
-Works, including the Software, are “made available” under this License by including in or with the Work either (a) a copyright notice referencing the applicability of this License to the Work, or (b) a copy of this License.
-2. License Grants
-2.1 Copyright Grant. Subject to the terms and conditions of this License, each Licensor grants to you a perpetual, worldwide, non-exclusive, royalty-free, copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense and distribute its Work and any resulting derivative works in any form.
-2.2 Patent Grant. Subject to the terms and conditions of this License, each Licensor grants to you a perpetual, worldwide, non-exclusive, royalty-free patent license to make, have made, use, sell, offer for sale, import, and otherwise transfer its Work, in whole or in part. The foregoing license applies only to the patent claims licensable by Licensor that would be infringed by Licensor’s Work (or portion thereof) individually and excluding any combinations with any other materials or technology.
-3. Limitations
-3.1 Redistribution. You may reproduce or distribute the Work only if (a) you do so under this License, (b) you include a complete copy of this License with your distribution, and (c) you retain without modification any copyright, patent, trademark, or attribution notices that are present in the Work.
-3.2 Derivative Works. You may specify that additional or different terms apply to the use, reproduction, and distribution of your derivative works of the Work (“Your Terms”) only if (a) Your Terms provide that the use limitation in Section 3.3 applies to your derivative works, and (b) you identify the specific derivative works that are subject to Your Terms. Notwithstanding Your Terms, this License (including the redistribution requirements in Section 3.1) will continue to apply to the Work itself.
-3.3 Use Limitation. The Work and any derivative works thereof only may be used or intended for use with the web services, computing platforms or applications provided by Amazon.com, Inc. or its affiliates, including Amazon Web Services, Inc.
-3.4 Patent Claims. If you bring or threaten to bring a patent claim against any Licensor (including any claim, cross-claim or counterclaim in a lawsuit) to enforce any patents that you allege are infringed by any Work, then your rights under this License from such Licensor (including the grants in Sections 2.1 and 2.2) will terminate immediately.
-3.5 Trademarks. This License does not grant any rights to use any Licensor’s or its affiliates’ names, logos, or trademarks, except as necessary to reproduce the notices described in this License.
-3.6 Termination. If you violate any term of this License, then your rights under this License (including the grants in Sections 2.1 and 2.2) will terminate immediately.
-4. Disclaimer of Warranty.
-THE WORK IS PROVIDED “AS IS” WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WARRANTIES OR CONDITIONS OF M ERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR NON-INFRINGEMENT. YOU BEAR THE RISK OF UNDERTAKING ANY ACTIVITIES UNDER THIS LICENSE. SOME STATES’ CONSUMER LAWS DO NOT ALLOW EXCLUSION OF AN IMPLIED WARRANTY, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.
-5. Limitation of Liability.
-EXCEPT AS PROHIBITED BY APPLICABLE LAW, IN NO EVENT AND UNDER NO LEGAL THEORY, WHETHER IN TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE SHALL ANY LICENSOR BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR RELATED TO THIS LICENSE, THE USE OR INABILITY TO USE THE WORK (INCLUDING BUT NOT LIMITED TO LOSS OF GOODWILL, BUSINESS INTERRUPTION, LOST PROFITS OR DATA, COMPUTER FAILURE OR MALFUNCTION, OR ANY OTHER COMM ERCIAL DAMAGES OR LOSSES), EVEN IF THE LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
-Effective Date – April 18, 2008 © 2008 Amazon.com, Inc. or its affiliates. All rights reserved.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-Note: Other license terms may apply to certain, identified software files contained within or
-distributed with the accompanying software if such terms are included in the directory containing
-the accompanying software. Such other license terms will then apply in lieu of the terms of the
-software license above.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,8 +1,8 @@
 AWS Centralized Logging Solution
 
-Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-Licensed under the Amazon Software License (the "License"). You may not use this file except
-in compliance with the License. A copy of the License is located at http://aws.amazon.com/asl/
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License Version 2.0 (the "License"). You may not use this file except
+in compliance with the License. A copy of the License is located at http://www.apache.org/licenses/
 or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the
 specific language governing permissions and limitations under the License.
@@ -13,7 +13,14 @@ THIRD PARTY COMPONENTS
 This software includes third party software subject to the following copyrights:
 
 AWS SDK under the Apache License Version 2.0
+aws-sdk-mock under the Apache License Version 2.
+chai under the Massachusetts Institute of Technology (MIT) license
 https under the Massachusetts Institute of Technology (MIT) license
+mocha under the Massachusetts Institute of Technology (MIT) license
 moment under the Massachusetts Institute of Technology (MIT) license
-
-The licenses for these third party components are included in LICENSE.txt
+npm-run-all under the Massachusetts Institute of Technology (MIT) license
+nyc under the ISC License
+sinon under The 3-Clause BSD License
+sinon-chai under The 2-Clause BSD License
+stream under the Massachusetts Institute of Technology (MIT) license
+uuid under the Massachusetts Institute of Technology (MIT) license

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The AWS Centralized Logging Solution project consists of indexing microservices 
 ```
 ***
 
-## v3.0.0 changes
+## v3.0.1 changes
 ```
 * Amazon Cognito integration for user login
 * Elasticsearch version update to 6.3
@@ -68,10 +68,11 @@ The AWS Centralized Logging Solution project consists of indexing microservices 
 
 ***
 
-Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-Licensed under the Amazon Software License (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
+Licensed under the Apache License Version 2.0 (the "License"). You may not use this file except in compliance with the License. A copy of the License is located at
 
-    http://aws.amazon.com/asl/
+    http://www.apache.org/licenses/
 
 or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
+

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ The AWS Centralized Logging Solution is a reference implementation that provides
 ## Getting Started
 To get started with the AWS Centralized Logging Solution, please review the solution documentation. https://aws.amazon.com/answers/logging/centralized-logging/
 
+## Upgrading to v3.2
+Customers using v3.0.0 can upgrade to v3.2 by loading the new primary template. Spoke templates, however, must be removed and installed from the v3.2 spoke template.
+
 ## Running unit tests for customization
 * Clone the repository, then make the desired code changes
 * Next, run unit tests to make sure added customization passes the tests

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -1,43 +1,103 @@
-if [ -z "$1" ] || [ -z "$2" ]; then
-    echo "Please provide the base source bucket name and version (subfolder) where the lambda code will eventually reside."
-    echo "For example: ./build-s3-dist.sh solutions v1.0.0"
-    exit 1
-fi
+#!/bin/bash 
+# 
+# This assumes all of the OS-level configuration has been completed and git repo has already been cloned 
+# 
+# This script should be run from the repo's deployment directory 
+# cd deployment 
+# ./build-s3-dist.sh source-bucket-base-name trademarked-solution-name version-code 
+# 
+# Paramenters: 
+#  - source-bucket-base-name: Name for the S3 bucket location where the template will source the Lambda 
+#    code from. The template will append '-[region_name]' to this bucket name. 
+#    For example: ./build-s3-dist.sh solutions my-solution v1.0.0 
+#    The template will then expect the source code to be located in the solutions-[region_name] bucket 
+# 
+#  - trademarked-solution-name: name of the solution for consistency 
+# 
+#  - version-code: version of the package 
+ 
+# Check to see if input has been provided: 
+if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then 
+    echo "Please provide the base source bucket name, trademark approved solution name and version where the lambda code will eventually reside." 
+    echo "For example: ./build-s3-dist.sh solutions trademarked-solution-name v1.0.0" 
+    exit 1 
+fi 
 
-[ -e dist ] && rm -r dist
-echo "== mkdir -p dist"
-mkdir -p dist
+bucket=$1
+tmsn=$2
+version=$3
 
-echo "==cp *.template dist/"
-cp *.template dist/
+do_cmd () {
+	echo "------ EXEC $*"
+	$*
+}
+do_replace() {
+	replace="s/$2/$3/g"
+	file=$1
+	do_cmd sed -i -e $replace $file
+}
+ 
+# Get reference for all important folders 
+template_dir="$PWD" 
+template_dist_dir="$template_dir/global-s3-assets" 
+build_dist_dir="$template_dir/regional-s3-assets" 
+source_dir="$template_dir/../source" 
+ 
+echo "------------------------------------------------------------------------------" 
+echo "[Init] Clean old dist, node_modules and bower_components folders" 
+echo "------------------------------------------------------------------------------" 
+do_cmd rm -rf $template_dist_dir 
+do_cmd mkdir -p $template_dist_dir 
+do_cmd rm -rf $build_dist_dir 
+do_cmd mkdir -p $build_dist_dir 
+ 
+echo "------------------------------------------------------------------------------" 
+echo "[Packing] Templates" 
+echo "------------------------------------------------------------------------------" 
+for file in $template_dir/*.template
+do
+	do_cmd cp $file $template_dist_dir/ 
+done
+do_cmd cp basic-dashboard-71.json $template_dist_dir/
 
-echo "==cp ../source/services/indexing/lib/*.json dist/"
-cp ../source/services/indexing/lib/*.json dist/
+echo "------------------------------------------------------------------------------" 
+echo "[Updating Bucket name]"
+echo "------------------------------------------------------------------------------" 
+for file in $template_dist_dir/*.template
+do
+  	do_replace $file '%%BUCKET_NAME%%' $bucket
+done
+ 
+echo "------------------------------------------------------------------------------" 
+echo "[Updating Solution name]"
+echo "------------------------------------------------------------------------------" 
+for file in $template_dist_dir/*.template
+do
+	do_replace $file '%%SOLUTION_NAME%%' $tmsn
+done
 
-echo "==Updating template mappings"
-replace="s/%%BUCKET_NAME%%/$1/g"
-sed -i '' -e $replace dist/*.template
+echo "------------------------------------------------------------------------------" 
+echo "[Updating version name]"
+echo "------------------------------------------------------------------------------" 
+for file in $template_dist_dir/*.template
+do
+	do_replace $file '%%VERSION%%' $version
+done
 
-replace="s/%%TEMPLATE_BUCKET%%/$2/g"
-sed -i '' -e $replace dist/*.template
-
-replace="s/%%VERSION%%/$3/g"
-sed -i '' -e $replace dist/*.template
-
-echo "==Download the AMI ID lookup package from S3"
-echo 'wget https://s3.amazonaws.com/cloudformation-examples/lambda/amilookup.zip; mv amilookup.zip dist/clog-ami-lookup.zip'
-wget https://s3.amazonaws.com/cloudformation-examples/lambda/amilookup.zip; mv amilookup.zip dist/clog-ami-lookup.zip
-
-echo "==Package indexing code"
-cd ../source/services/indexing
+echo "------------------------------------------------------------------------------" 
+echo "[Rebuild] Indexing Code" 
+echo "------------------------------------------------------------------------------"
+cd $source_dir/services/indexing
 npm install
 npm run build
 npm run zip
-cp dist/clog-indexing-service.zip ../../../deployment/dist/clog-indexing-service.zip
+cp dist/clog-indexing-service.zip $build_dist_dir/clog-indexing-service.zip
 
-echo "==Package auth code"
-cd ../../../source/services/auth
+echo "------------------------------------------------------------------------------" 
+echo "[Rebuild] Auth code"  
+echo "------------------------------------------------------------------------------" 
+cd $source_dir/services/auth
 npm install
 npm run build
 npm run zip
-cp dist/clog-auth.zip ../../../deployment/dist/clog-auth.zip
+cp dist/clog-auth.zip $build_dist_dir/clog-auth.zip

--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -58,7 +58,7 @@ for file in $template_dir/*.template
 do
 	do_cmd cp $file $template_dist_dir/ 
 done
-do_cmd cp basic-dashboard-71.json $template_dist_dir/
+do_cmd cp basic-dashboard-63.json $template_dist_dir/
 
 echo "------------------------------------------------------------------------------" 
 echo "[Updating Bucket name]"

--- a/deployment/centralized-logging-demo.template
+++ b/deployment/centralized-logging-demo.template
@@ -6,7 +6,7 @@
 # author: aws-solutions-builder@
 AWSTemplateFormatVersion: 2010-09-09
 
-Description: (SO0009d) - AWS Centralized Logging Solution, sample sources template
+Description: (SO0009d) - AWS Centralized Logging Solution, sample sources template (Version %%VERSION%%)
 
 Parameters:
   # Log Streamer Function Arn
@@ -34,6 +34,13 @@ Parameters:
     Default: 10.250.250.0/24
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x
 
+  LatestAMIId:
+    Description: >-
+      Automatically selects the latest Amazon Linux AMI. Do not change this
+      value
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: /aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -51,24 +58,11 @@ Metadata:
         default: Lambda Arn for Log Streaming
 
 Mappings:
-  # Instance mapping for different regions
-  InstanceMap:
-    t2.micro: {"Arch":"HVM64"}
-    us-east-1: {"instancetype":"t2.micro"}
-    us-east-2: {"instancetype":"t2.micro"}
-    us-west-1: {"instancetype":"t2.micro"}
-    us-west-2: {"instancetype":"t2.micro"}
-    ca-central-1: {"instancetype":"t2.micro"}
-    eu-west-1: {"instancetype":"t2.micro"}
-    eu-central-1: {"instancetype":"t2.micro"}
-    eu-west-2: {"instancetype":"t2.micro"}
-    eu-west-3: {"instancetype":"t2.micro"}
-    ap-southeast-1: {"instancetype":"t2.micro"}
-    ap-southeast-2: {"instancetype":"t2.micro"}
-    ap-northeast-1: {"instancetype":"t2.micro"}
-    ap-northeast-2: {"instancetype":"t2.micro"}
-    ap-south-1: {"instancetype":"t2.micro"}
-    sa-east-1: {"instancetype":"t2.micro"}
+
+  # Instance type for demo box
+  EC2: 
+    Instance: 
+      Type: 't3.micro' 
 
   # CloudWatch logs pattern mapping
   FilterPatternLookup:
@@ -84,12 +78,6 @@ Mappings:
       Pattern: '[]'
     Other:
       Pattern: ''
-
-  # Lambda source code mapping
-  SourceCode:
-    General:
-      S3Bucket: "%%BUCKET_NAME%%"
-      KeyPrefix: "centralized-logging/%%VERSION%%"
 
 Resources:
   #
@@ -114,6 +102,11 @@ Resources:
       Tags:
       - Key: Name
         Value: centralized-logging-demo subnet
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W33
+            reason: "This is where the test webserver is deployed for for a static page to demo the functionality of the solution by generating log for demo purposes. Hence requires a public IP"
 
   InternetGateway:
     Type: AWS::EC2::InternetGateway
@@ -155,7 +148,7 @@ Resources:
       RetentionInDays: 1
 
   FlowlogsRole:
-    Type: AWS::IAM::Role
+    Type: AWS::IAM::Role 
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -180,6 +173,11 @@ Resources:
             - logs:DescribeLogStreams
             - logs:PutLogEvents
             Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: "Push logs from various resources to cloudwatch logs. Hence open"
 
   VPCFlowLog:
     Type: AWS::EC2::FlowLog
@@ -197,6 +195,33 @@ Resources:
       FilterPattern: !FindInMap [FilterPatternLookup, FlowLogs, Pattern]
       LogGroupName: !Sub ${VPCFlowLogGroup}
 
+  S3LoggingBucket:
+    DeletionPolicy: Retain
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub aws-trailbucket-s3-access-logs-${AWS::AccountId}-${AWS::Region}
+      AccessControl: LogDeliveryWrite
+      VersioningConfiguration:
+        Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      Tags:
+        - Key: Name
+          Value: 'AWS Centralized Logging Demo'
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        BlockPublicPolicy: True
+        IgnorePublicAcls: True
+        RestrictPublicBuckets: True
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W35
+            reason: "This S3 bucket is used as the destination for storing access logs"
+          - id: W51
+            reason: "Log delivery controlled by ACL, not bucket policy"
 
   #
   # CloudTrail resources
@@ -205,11 +230,27 @@ Resources:
   TrailBucket:
     DeletionPolicy: Retain
     Type: AWS::S3::Bucket
+    Properties:
+      LoggingConfiguration:
+        DestinationBucketName: !Ref S3LoggingBucket
+        LogFilePrefix: access-logs
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      Tags:
+        - Key: Name
+          Value: 'AWS Centralized Logging Demo'
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        BlockPublicPolicy: True
+        IgnorePublicAcls: True
+        RestrictPublicBuckets: True
 
   TrailBucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:
-      Bucket: !Sub ${TrailBucket}
+      Bucket: !Ref TrailBucket
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -279,14 +320,7 @@ Resources:
   # [EC2LogRole, InstanceProfile, WebServerSecurityGroup, WebServerSecurityGroupIngress, WebServerLogtoLambda]
   #
   EC2LogRole:
-    Type: AWS::IAM::Role
-    ##
-    # V56617021 - 10/08/2018 - Suppress cfn_nag
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-        - id: F3
-          reason: Override the IAM role to allow logs:Create* action on its permissions policy
+    Type: AWS::IAM::Role  
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -310,7 +344,7 @@ Resources:
               - s3:GetObject
               Resource:
               - !Sub ${WebServerLogGroup.Arn}
-              - arn:aws:s3:::*
+              - !GetAtt TrailBucket.Arn
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -409,7 +443,7 @@ Resources:
       ResourceSignal:
         Timeout: PT15M
     Properties:
-      ImageId: !Sub ${AMIInfo.Id}
+      ImageId: !Ref LatestAMIId
       Tags:
       - Key: Name
         Value: Web Server centralized-logging-demo
@@ -420,7 +454,7 @@ Resources:
         DeviceIndex: 0
         DeleteOnTermination: true
         SubnetId: !Sub ${PublicSubnet}
-      InstanceType: !FindInMap [InstanceMap, !Ref "AWS::Region", "instancetype"]
+      InstanceType: !FindInMap [EC2, Instance, Type]
       IamInstanceProfile: !Sub ${InstanceProfile}
       UserData: !Base64
         'Fn::Join':
@@ -484,8 +518,8 @@ Resources:
     Metadata:
       cfn_nag:
         rules_to_suppress:
-        - id: F1000
-          reason: Override the SecurityGroup, egress rule defined as well
+          - id: F1000
+            reason: Override the SecurityGroup, egress rule defined as well
     Properties:
       GroupDescription: Enable HTTP access via port 80
       VpcId: !Sub ${DemoVPC}
@@ -493,20 +527,36 @@ Resources:
   WebServerSecurityGroupIngress:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
+      Description: Allow inbound access to the webserver from the internet
       GroupId: !Sub ${WebServerSecurityGroup}
       IpProtocol: tcp
       FromPort: 80
       ToPort: 80
       CidrIp: 0.0.0.0/0
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W9
+            reason: "The server is a public webserver and hence CIDR mask is open"
+          - id: W2
+            reason: "To demo the functionality of this solution, there is public facing webserver with which the SecurityGroup will be associated. This webserver instance will be used only as a mechanism to generate logs. Hence no ELB has been added to the infrastructure"
 
   WebServerSecurityGroupEgress:
     Type: AWS::EC2::SecurityGroupEgress
     Properties:
+      Description: Allow outbound access to the internet for all requests coming in
       CidrIp: 0.0.0.0/0
       FromPort: 0
       GroupId: !Sub ${WebServerSecurityGroup}
       IpProtocol: tcp
       ToPort: 65535
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W5
+            reason: "The webserver is a public access server and hence CIDR range is open"
+          - id: W29
+            reason: "The TCP/IP protocol requires the ephemeral port range for communication over the internet for a public server"
 
   WebServerLogtoLambda:
     Type: AWS::Logs::SubscriptionFilter
@@ -514,57 +564,6 @@ Resources:
       DestinationArn: !Sub ${LogStreamerArn}
       FilterPattern: !FindInMap [FilterPatternLookup, Common, Pattern]
       LogGroupName: !Sub ${WebServerLogGroup}
-
-
-  #
-  # Solution Helper resources
-  # [AMIInfoFunction, AMIInfo, SolutionHelperRole]
-  #
-  AMIInfoFunction:
-    Type: AWS::Lambda::Function
-    Properties:
-      Code:
-        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
-        S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "clog-ami-lookup.zip"]]
-      Handler: amilookup.handler
-      Runtime: nodejs8.10
-      Timeout: 300
-      Description: This function is CloudFormation custom lambda resource that looks up the latest AMI ID.
-      Role: !Sub ${SolutionHelperRole.Arn}
-
-  AMIInfo:
-    Type: Custom::AMIInfo
-    Properties:
-      ServiceToken: !GetAtt AMIInfoFunction.Arn
-      Region: !Ref "AWS::Region"
-      Architecture: !FindInMap [InstanceMap, !FindInMap [InstanceMap, !Ref "AWS::Region", "instancetype"], "Arch"]
-
-  SolutionHelperRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: lambda.amazonaws.com
-          Action: sts:AssumeRole
-      Path: /
-      Policies:
-      - PolicyName: Custom_Lambda_Loader_Permissions
-        PolicyDocument:
-          Version: 2012-10-17
-          Statement:
-          - Effect: Allow
-            Action:
-            - logs:CreateLogGroup
-            - logs:CreateLogStream
-            - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
-          - Effect: Allow
-            Action:
-            - ec2:DescribeImages
-            Resource: "*"
 
 Outputs:
   PublicIP:

--- a/deployment/centralized-logging-primary.template
+++ b/deployment/centralized-logging-primary.template
@@ -18,15 +18,13 @@ Parameters:
   # Email address for the Elasticsearch domain admin
   DomainAdminEmail:
     Type: String
-    Default: esdomainadmin@example.com
-    AllowedPattern: '^\w+([\.-\\+]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'
+    AllowedPattern: '^[_A-Za-z0-9-\+\.]+(\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\.[A-Za-z0-9]+)*(\.[A-Za-z]{2,})$'
     Description: E-mail address of the Elasticsearch admin
 
   # Email address for Cognito Admin user
   CognitoAdminEmail:
     Type: String
-    Default: cognitoadmin@example.com
-    AllowedPattern: '^\w+([\.-\\+]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'
+    AllowedPattern: '^[_A-Za-z0-9-\+\.]+(\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\.[A-Za-z0-9]+)*(\.[A-Za-z]{2,})$'
     Description: E-mail address of the Cognito admin
 
   # ES cluster size
@@ -117,7 +115,7 @@ Mappings:
 
   ElasticSearch:
     Parameters:
-      Version: '7.1'
+      Version: '6.3'
     NodeCount:
       Small: '4'
       Medium: '6'
@@ -173,7 +171,7 @@ Resources:
     Type: 'Custom::SetupESCognito'
     Version: 1.0
     Properties:
-      ServiceToken: !GetAtt CLSolutionHelper.Arn
+      ServiceToken: !GetAtt LambdaESCognito.Arn
       Domain: !Ref DOMAINNAME
       CognitoDomain: !Sub ${DOMAINNAME}-${AWS::AccountId}
       UserPoolId: !Ref UserPool
@@ -188,7 +186,7 @@ Resources:
       UserPoolId: !Ref UserPool
 
   # Creates a group in Cognito for Kibana ADMIN access
-  UserPoolGroupAccess:
+  UserPoolGroup:
     DeletionPolicy: 'Retain'
     Type: "AWS::Cognito::UserPoolGroup"
     Properties:
@@ -196,7 +194,7 @@ Resources:
       GroupName: !Sub ${DOMAINNAME}_kibana_admin
       Precedence: 0
       UserPoolId: !Ref UserPool
-      RoleArn: !GetAtt CLAccessUserRole.Arn
+      RoleArn: !GetAtt CognitoAuthorizedRole.Arn
 
   # Creates a User Pool Client to be used by the identity pool
   UserPoolClient:
@@ -226,9 +224,9 @@ Resources:
     Properties:
       IdentityPoolId: !Ref IdentityPool
       Roles:
-        authenticated: !GetAtt CLAccessUserRole.Arn
+        authenticated: !GetAtt CognitoAuthorizedRole.Arn
 
-  CLAccessUserRole:
+  CognitoAuthorizedRole:
     DeletionPolicy: 'Retain'
     Type: 'AWS::IAM::Role'
     Properties:
@@ -308,7 +306,7 @@ Resources:
               - 'sts:AssumeRole'
 
   # Create initial cognito user
-  CognitoUser:
+  AdminUser:
     Type: 'AWS::Cognito::UserPoolUser'
     DeletionPolicy: 'Retain'
     Properties:
@@ -324,11 +322,11 @@ Resources:
   CognitoUserGroupAttachment:
     Type: 'AWS::Cognito::UserPoolUserToGroupAttachment'
     Properties:
-      GroupName: !Ref UserPoolGroupAccess
+      GroupName: !Ref UserPoolGroup
       Username: !Ref CognitoAdminEmail
       UserPoolId: !Ref UserPool
 
-  CLSolutionHelper:
+  LambdaESCognito:
     Type: 'AWS::Lambda::Function'
     Properties:
       Description: Centralized Logging - Lambda solution helper functions
@@ -339,12 +337,12 @@ Resources:
       Handler: index.handler
       Runtime: nodejs12.x
       Timeout: 300
-      Role: !GetAtt CLSolutionHelperRole.Arn
+      Role: !GetAtt LambdaESCognitoRole.Arn
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "clog-auth.zip"]]
 
-  CLSolutionHelperRole:
+  LambdaESCognitoRole:
     Type: AWS::IAM::Role
     DependsOn: ElasticsearchAWSLogs
     Properties:
@@ -461,7 +459,7 @@ Resources:
           Principal:
             AWS: !Sub
               - arn:aws:sts::${AWS::AccountId}:assumed-role/${AuthRole}/CognitoIdentityCredentials
-              - { AuthRole: !Ref CLAccessUserRole }
+              - { AuthRole: !Ref CognitoAuthorizedRole }
           Effect: Allow
           Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DOMAINNAME}/*'
       # V57095985 - 10/08/2018 - ES Domain needed configurations
@@ -824,7 +822,7 @@ Resources:
   CreateUniqueID:
     Type: Custom::LoadLambda
     Properties:
-      ServiceToken: !GetAtt CLSolutionHelper.Arn
+      ServiceToken: !GetAtt LambdaESCognito.Arn
       Resource: UUID
 
 Outputs:

--- a/deployment/centralized-logging-primary.template
+++ b/deployment/centralized-logging-primary.template
@@ -6,7 +6,7 @@
 # author: aws-solutions-builder@
 AWSTemplateFormatVersion: 2010-09-09
 
-Description: (SO0009) - AWS Centralized Logging Solution, primary template
+Description: (SO0009) - AWS Centralized Logging Solution, primary template (Version %%VERSION%%)
 
 Parameters:
   # Name for ES Domain
@@ -19,14 +19,14 @@ Parameters:
   DomainAdminEmail:
     Type: String
     Default: esdomainadmin@example.com
-    AllowedPattern: '^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'
+    AllowedPattern: '^\w+([\.-\\+]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'
     Description: E-mail address of the Elasticsearch admin
 
   # Email address for Cognito Admin user
   CognitoAdminEmail:
     Type: String
     Default: cognitoadmin@example.com
-    AllowedPattern: '^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'
+    AllowedPattern: '^\w+([\.-\\+]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'
     Description: E-mail address of the Cognito admin
 
   # ES cluster size
@@ -115,30 +115,27 @@ Mappings:
   InstanceMap:
     send-data: {"SendAnonymousData": "Yes"}
 
-  # V57271571 - 10/09/2018 - update tshirt size
-  InstanceSizing:
-    elasticsearch:
-      Small: i3.large.elasticsearch
-      Medium: i3.2xlarge.elasticsearch
-      Large: i3.4xlarge.elasticsearch
-
-  MasterSizing:
-    elasticsearch:
-      Small: c4.large.elasticsearch
-      Medium: c4.large.elasticsearch
-      Large: c4.large.elasticsearch
-
-  NodeCount:
-    elasticsearch:
+  ElasticSearch:
+    Parameters:
+      Version: '7.1'
+    NodeCount:
       Small: '4'
       Medium: '6'
       Large: '6'
+    MasterSize:
+      Small: c5.large.elasticsearch
+      Medium: c5.large.elasticsearch
+      Large: c5.large.elasticsearch
+    InstanceSize:
+      Small: i3.large.elasticsearch
+      Medium: i3.2xlarge.elasticsearch
+      Large: i3.4xlarge.elasticsearch
 
   # Lambda source code mapping
   SourceCode:
     General:
       S3Bucket: "%%BUCKET_NAME%%"
-      KeyPrefix: "centralized-logging/%%VERSION%%"
+      KeyPrefix: "%%SOLUTION_NAME%%/%%VERSION%%"
 
 Conditions:
   DemoData: !Equals [!Ref DemoTemplate, 'Yes']
@@ -150,7 +147,7 @@ Resources:
   #
   # Creates a user pool in cognito to auth against
   UserPool:
-    DeletionPolicy: Retain
+    DeletionPolicy: 'Retain'
     Type: 'AWS::Cognito::UserPool'
     Properties:
       UserPoolName: !Sub ${DOMAINNAME}_kibana_access
@@ -168,19 +165,42 @@ Resources:
           Mutable: false
           Required: true
 
-  # Creates a needed group in Cognito for Kibana access
-  UserPoolGroup:
-    DeletionPolicy: Retain
+  # Custom resource to configure Cognito and ES
+  SetupESCognito:
+    DependsOn: 
+      - 'ElasticsearchAWSLogs'
+      - 'UserPoolDomain'
+    Type: 'Custom::SetupESCognito'
+    Version: 1.0
+    Properties:
+      ServiceToken: !GetAtt CLSolutionHelper.Arn
+      Domain: !Ref DOMAINNAME
+      CognitoDomain: !Sub ${DOMAINNAME}-${AWS::AccountId}
+      UserPoolId: !Ref UserPool
+      IdentityPoolId: !Ref IdentityPool
+      RoleArn: !GetAtt CognitoESAccessRole.Arn
+
+  UserPoolDomain:
+    DeletionPolicy: 'Retain'
+    Type: 'AWS::Cognito::UserPoolDomain'
+    Properties:
+      Domain: !Sub ${DOMAINNAME}-${AWS::AccountId}
+      UserPoolId: !Ref UserPool
+
+  # Creates a group in Cognito for Kibana ADMIN access
+  UserPoolGroupAccess:
+    DeletionPolicy: 'Retain'
     Type: "AWS::Cognito::UserPoolGroup"
     Properties:
-      Description: 'User pool group for Kibana access'
-      GroupName: !Sub ${DOMAINNAME}_kibana_access_group
+      Description: 'User pool group for Kibana full access'
+      GroupName: !Sub ${DOMAINNAME}_kibana_admin
       Precedence: 0
       UserPoolId: !Ref UserPool
+      RoleArn: !GetAtt CLAccessUserRole.Arn
 
   # Creates a User Pool Client to be used by the identity pool
   UserPoolClient:
-    DeletionPolicy: Retain
+    DeletionPolicy: 'Retain'
     Type: 'AWS::Cognito::UserPoolClient'
     Properties:
       ClientName: !Sub ${DOMAINNAME}-client
@@ -189,56 +209,27 @@ Resources:
 
   # Creates a federated Identity pool
   IdentityPool:
-    DeletionPolicy: Retain
+    DeletionPolicy: 'Retain'
     Type: 'AWS::Cognito::IdentityPool'
     Properties:
       IdentityPoolName: !Sub ${DOMAINNAME}Identity
-      AllowUnauthenticatedIdentities: true
+      AllowUnauthenticatedIdentities: false # Prevent anonymous access
       CognitoIdentityProviders:
         - ClientId: !Ref UserPoolClient
           ProviderName: !GetAtt UserPool.ProviderName
+          ServerSideTokenCheck: true
 
-  # Create a role for unauthorized access to AWS resources. Very limited access.
-  # Only allows users in the previously created Identity Pool
-  CognitoUnAuthorizedRole:
-    DeletionPolicy: Retain
-    Type: 'AWS::IAM::Role'
+  # Assigns the roles to the Identity Pool
+  IdentityPoolRoleMapping:
+    DeletionPolicy: 'Retain'
+    Type: 'AWS::Cognito::IdentityPoolRoleAttachment'
     Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Effect: 'Allow'
-            Principal:
-              Federated: 'cognito-identity.amazonaws.com'
-            Action:
-              - 'sts:AssumeRoleWithWebIdentity'
-            Condition:
-              StringEquals:
-                'cognito-identity.amazonaws.com:aud': !Ref IdentityPool
-              'ForAnyValue:StringLike':
-                'cognito-identity.amazonaws.com:amr': unauthenticated
-      Policies:
-        - PolicyName: 'CognitoUnauthorizedPolicy'
-          PolicyDocument:
-            Version: '2012-10-17'
-            Statement:
-              - Effect: 'Allow'
-                Action:
-                  - 'mobileanalytics:PutEvents'
-                  - 'cognito-sync:BulkPublish'
-                  - 'cognito-sync:DescribeIdentityPoolUsage'
-                  - 'cognito-sync:GetBulkPublishDetails'
-                  - 'cognito-sync:GetCognitoEvents'
-                  - 'cognito-sync:GetIdentityPoolConfiguration'
-                  - 'cognito-sync:ListIdentityPoolUsage'
-                  - 'cognito-sync:SetCognitoEvents'
-                  - 'congito-sync:SetIdentityPoolConfiguration'
-                Resource: !Sub 'arn:aws:cognito-identity:${AWS::Region}:${AWS::AccountId}:identitypool/${IdentityPool}'
+      IdentityPoolId: !Ref IdentityPool
+      Roles:
+        authenticated: !GetAtt CLAccessUserRole.Arn
 
-  # Create a role for authorized access to AWS resources.
-  # Only allows users in the previously created Identity Pool
-  CognitoAuthorizedRole:
-    DeletionPolicy: Retain
+  CLAccessUserRole:
+    DeletionPolicy: 'Retain'
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:
@@ -255,38 +246,58 @@ Resources:
               'ForAnyValue:StringLike':
                 'cognito-identity.amazonaws.com:amr': authenticated
       Policies:
-        - PolicyName: 'CognitoAuthorizedPolicy'
+        - PolicyName: 'CognitoAccessPolicy'
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
               - Effect: 'Allow'
-                Action:
-                  - 'mobileanalytics:PutEvents'
-                  - 'cognito-sync:BulkPublish'
-                  - 'cognito-sync:DescribeIdentityPoolUsage'
-                  - 'cognito-sync:GetBulkPublishDetails'
-                  - 'cognito-sync:GetCognitoEvents'
-                  - 'cognito-sync:GetIdentityPoolConfiguration'
-                  - 'cognito-sync:ListIdentityPoolUsage'
-                  - 'cognito-sync:SetCognitoEvents'
-                  - 'congito-sync:SetIdentityPoolConfiguration'
-                  - 'cognito-identity:DeleteIdentityPool'
-                  - 'cognito-identity:DescribeIdentityPool'
-                  - 'cognito-identity:GetIdentityPoolRoles'
-                  - 'cognito-identity:GetOpenIdTokenForDeveloperIdentity'
-                  - 'cognito-identity:ListIdentities'
-                  - 'cognito-identity:LookupDeveloperIdentity'
-                  - 'cognito-identity:MergeDeveloperIdentities'
-                  - 'cognito-identity:UnlikeDeveloperIdentity'
-                  - 'cognito-identity:UpdateIdentityPool'
-                Resource: !Sub 'arn:aws:cognito-identity:${AWS::Region}:${AWS::AccountId}:identitypool/${IdentityPool}'
+                Action: 
+                  - 'es:ESHttp*'
+                Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DOMAINNAME}/*'
 
+  # Policy passed to the ES API to execute updateElasticsearchDomainConfig
+  CognitoESAccessPolicy:
+    Type: 'AWS::IAM::Policy'
+    DeletionPolicy: 'Retain'
+    Properties:
+      PolicyName: 'CentralizedLoggingESCognitoAccess'
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ESCognitoPerms
+            Effect: Allow
+            Action:
+              - 'cognito-idp:DescribeUserPool'
+              - 'cognito-idp:CreateUserPoolClient'
+              - 'cognito-idp:DeleteUserPoolClient'
+              - 'cognito-idp:DescribeUserPoolClient'
+              - 'cognito-idp:AdminInitiateAuth'
+              - 'cognito-idp:AdminUserGlobalSignOut'
+              - 'cognito-idp:ListUserPoolClients'
+              - 'cognito-identity:DescribeIdentityPool'
+              - 'cognito-identity:UpdateIdentityPool'
+              - 'cognito-identity:SetIdentityPoolRoles'
+              - 'cognito-identity:GetIdentityPoolRoles'
+              - 'es:UpdateElasticsearchDomainConfig'
+            Resource: 
+              - !Sub 'arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${UserPool}'
+              - !Sub 'arn:aws:cognito-identity:${AWS::Region}:${AWS::AccountId}:identitypool/${IdentityPool}'
+              - !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DOMAINNAME}'
+          - Sid: 'PassRole'
+            Effect: 'Allow'
+            Action: 'iam:PassRole'
+            Condition:
+              StringLike: 
+                'iam:PassedToService': 'cognito-identity.amazonaws.com'
+            Resource: !GetAtt CognitoESAccessRole.Arn
+      Roles: 
+        - !Ref CognitoESAccessRole
+
+  # with CognitoESAcessPolicy above
   CognitoESAccessRole:
     Type: 'AWS::IAM::Role'
-    DeletionPolicy: Retain
+    DeletionPolicy: 'Retain'
     Properties:
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonESCognitoAccess
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -296,19 +307,10 @@ Resources:
             Action:
               - 'sts:AssumeRole'
 
-  # Assigns the roles to the Identity Pool
-  IdentityPoolRoleMapping:
-    DeletionPolicy: Retain
-    Type: 'AWS::Cognito::IdentityPoolRoleAttachment'
-    Properties:
-      IdentityPoolId: !Ref IdentityPool
-      Roles:
-        authenticated: !GetAtt CognitoAuthorizedRole.Arn
-        unauthenticated: !GetAtt CognitoUnAuthorizedRole.Arn
-
-  AdminUser:
+  # Create initial cognito user
+  CognitoUser:
     Type: 'AWS::Cognito::UserPoolUser'
-    DeletionPolicy: Retain
+    DeletionPolicy: 'Retain'
     Properties:
       DesiredDeliveryMediums:
         - 'EMAIL'
@@ -318,35 +320,31 @@ Resources:
       Username: !Ref CognitoAdminEmail
       UserPoolId: !Ref UserPool
 
-  # Custom resource to configure Cognito and ES
-  SetupESCognito:
-    Type: 'Custom::SetupESCognito'
-    Version: 1.0
+  # Place user in UserPoolGroup
+  CognitoUserGroupAttachment:
+    Type: 'AWS::Cognito::UserPoolUserToGroupAttachment'
     Properties:
-      ServiceToken: !GetAtt LambdaESCognito.Arn
-      Domain: !Ref DOMAINNAME
-      CognitoDomain: !Sub ${DOMAINNAME}-${AWS::AccountId}
+      GroupName: !Ref UserPoolGroupAccess
+      Username: !Ref CognitoAdminEmail
       UserPoolId: !Ref UserPool
-      IdentityPoolId: !Ref IdentityPool
-      RoleArn: !GetAtt CognitoESAccessRole.Arn
 
-  LambdaESCognito:
+  CLSolutionHelper:
     Type: 'AWS::Lambda::Function'
     Properties:
-      Description: Centralized Logging - Lambda function to enable cognito authentication for kibana
+      Description: Centralized Logging - Lambda solution helper functions
       Environment:
         Variables:
           # V56536055 - 10/08/2018 - better logging capabilities
           LOG_LEVEL: 'INFO' #change to WARN, ERROR or DEBUG as needed
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 300
-      Role: !GetAtt LambdaESCognitoRole.Arn
+      Role: !GetAtt CLSolutionHelperRole.Arn
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "clog-auth.zip"]]
 
-  LambdaESCognitoRole:
+  CLSolutionHelperRole:
     Type: AWS::IAM::Role
     DependsOn: ElasticsearchAWSLogs
     Properties:
@@ -384,12 +382,18 @@ Resources:
             Action:
             - iam:PassRole
             Resource: !GetAtt CognitoESAccessRole.Arn
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: "CloudWatch Logs captures logs from various resources and hence it is open"
 
   #
   # Primer Elasticsearch resources
   # [LoggingMasterRole, LoggingMasterPolicies, ElasticsearchAWSLogs]
   #
   LoggingMasterRole:
+    DeletionPolicy: 'Retain'
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -408,6 +412,7 @@ Resources:
       Path: "/"
 
   LoggingMasterPolicies:
+    DeletionPolicy: 'Retain' 
     Type: AWS::IAM::Policy
     Properties:
       PolicyName: !Sub logging-master-${AWS::Region}
@@ -420,38 +425,43 @@ Resources:
           Resource: !Sub arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/*
       Roles:
       - !Ref LoggingMasterRole
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W12
+            reason: "Allow resources to hit ES domains"
 
   ElasticsearchAWSLogs:
     Type: AWS::Elasticsearch::Domain
-    DeletionPolicy: Retain
+    DeletionPolicy: 'Retain'
     Properties:
       DomainName: !Ref DOMAINNAME
-      ElasticsearchVersion: 6.3
+      ElasticsearchVersion: !FindInMap [ElasticSearch, Parameters, Version]
       # V5804310 - 10/09/2018 - ES Encryption at rest
       EncryptionAtRestOptions:
         Enabled: true
       ElasticsearchClusterConfig:
         DedicatedMasterEnabled: true
-        InstanceCount: !FindInMap [NodeCount, elasticsearch, !Ref ClusterSize]
+        InstanceCount: !FindInMap [ElasticSearch, NodeCount, !Ref ClusterSize]
         ZoneAwarenessEnabled: true
-        InstanceType: !FindInMap [InstanceSizing, elasticsearch, !Ref ClusterSize]
-        DedicatedMasterType: !FindInMap [MasterSizing, elasticsearch, !Ref ClusterSize]
+        InstanceType: !FindInMap [ElasticSearch, InstanceSize, !Ref ClusterSize]
+        DedicatedMasterType: !FindInMap [ElasticSearch, MasterSize, !Ref ClusterSize]
         DedicatedMasterCount: 3
       SnapshotOptions:
         AutomatedSnapshotStartHour: '1'
       AccessPolicies:
         Version: 2012-10-17
         Statement:
-        - Action: 'es:*'
+        - Action: 'es:ESHttp*'
           Principal:
             AWS: !Sub ${LoggingMasterRole.Arn}
           Effect: Allow
-          Resource: !Sub arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/* #removing domain name due to cyclic dependency
-        - Action: 'es:*'
+          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DOMAINNAME}/*'
+        - Action: 'es:ESHttp*'
           Principal:
             AWS: !Sub
               - arn:aws:sts::${AWS::AccountId}:assumed-role/${AuthRole}/CognitoIdentityCredentials
-              - { AuthRole: !Ref CognitoAuthorizedRole }
+              - { AuthRole: !Ref CLAccessUserRole }
           Effect: Allow
           Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DOMAINNAME}/*'
       # V57095985 - 10/08/2018 - ES Domain needed configurations
@@ -459,12 +469,22 @@ Resources:
       AdvancedOptions:
         rest.action.multi.allow_explicit_index: 'true'
         indices.fielddata.cache.size: 40
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: "The ES Domain is passed dynamically as as parameter and explicitly specified to ensure that IAM policies are configured to lockdown access to this specific ES instance only"
 
   #
   # SNS Topic
   #
   Topic:
     Type: 'AWS::SNS::Topic'
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W47
+            reason: "Suppressing latest warning"
     Properties:
       DisplayName: 'Centralized Logging CloudWatch alarms notification topic'
 
@@ -721,6 +741,7 @@ Resources:
   # [LogStreamerRole, LogStreamer, LogStreamerInvokePermission, DemoStack]
   #
   LogStreamerRole:
+    DeletionPolicy: 'Retain'
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:
@@ -746,10 +767,12 @@ Resources:
               Action:
               - es:ESHttpPost
               Resource: !Sub arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/*
-            # - Effect: Allow
-            #   Action:
-            #   - sts:AssumeRole
-            #   Resource: !Sub ${LoggingMasterRole.Arn}
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: "The resource for log-group is restricted to lambda functions. The name of the fuction is not specified because if specified any change to lambda function would require replacement"
+
 
   LogStreamer:
     Type: AWS::Lambda::Function
@@ -772,7 +795,7 @@ Resources:
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "clog-indexing-service.zip"]]
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 300
 
   LogStreamerInvokePermission:
@@ -791,18 +814,23 @@ Resources:
         LogStreamerArn: !Sub ${LogStreamer.Arn}
         DemoVPCCidr: !Sub ${DemoVPC}
         DemoSubnet: !Sub ${DemoSubnet}
-      TemplateURL: !Join ["/", ["https://s3.amazonaws.com/%%TEMPLATE_BUCKET%%", !FindInMap ["SourceCode", "General", "KeyPrefix"], "centralized-logging-demo.template"]]
+      TemplateURL: !Join 
+        - ''
+        - - 'https://'
+          - !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], "reference"]]
+          - '.s3.amazonaws.com/'
+          - !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "centralized-logging-demo.template"]]
 
   CreateUniqueID:
     Type: Custom::LoadLambda
     Properties:
-      ServiceToken: !GetAtt LambdaESCognito.Arn
+      ServiceToken: !GetAtt CLSolutionHelper.Arn
       Resource: UUID
 
 Outputs:
   DomainEndpoint:
     Description: ES domain endpoint URL
-    Value: !Sub https://${ElasticsearchAWSLogs.DomainEndpoint}
+    Value: !Sub ${ElasticsearchAWSLogs.DomainEndpoint}
 
   KibanaLoginURL:
     Description: Kibana login URL

--- a/deployment/centralized-logging-spoke.template
+++ b/deployment/centralized-logging-spoke.template
@@ -187,9 +187,9 @@ Resources:
 
   #
   # Solution Helper resources
-  # [CLSolutionHelperRole, CLSolutionHelper, CreateUniqueID]
+  # [SolutionHelperRole, SolutionHelper, CreateUniqueID]
   #
-  CLSolutionHelper:
+  SolutionHelper:
     Type: 'AWS::Lambda::Function'
     Properties:
       Description: Centralized Logging - Lambda function to generate a unique ID
@@ -200,12 +200,12 @@ Resources:
       Handler: index.handler
       Runtime: nodejs12.x
       Timeout: 300
-      Role: !GetAtt CLSolutionHelperRole.Arn
+      Role: !GetAtt SolutionHelperRole.Arn
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "clog-auth.zip"]]
 
-  CLSolutionHelperRole:
+  SolutionHelperRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -233,7 +233,7 @@ Resources:
   CreateUniqueID:
     Type: Custom::LoadLambda
     Properties:
-      ServiceToken: !GetAtt CLSolutionHelper.Arn
+      ServiceToken: !GetAtt SolutionHelper.Arn
       Resource: UUID
 
 Outputs:

--- a/deployment/centralized-logging-spoke.template
+++ b/deployment/centralized-logging-spoke.template
@@ -6,7 +6,7 @@
 # author: aws-solutions-builder@
 AWSTemplateFormatVersion: 2010-09-09
 
-Description: (SO0009s) - AWS Centralized Logging Solution, spoke accounts template
+Description: (SO0009s) - AWS Centralized Logging Solution, spoke accounts template (Version %%VERSION%%)
 
 Parameters:
   # Name for ES Domain
@@ -95,7 +95,7 @@ Mappings:
   SourceCode:
     General:
       S3Bucket: "%%BUCKET_NAME%%"
-      KeyPrefix: "centralized-logging/%%VERSION%%"
+      KeyPrefix: "%%SOLUTION_NAME%%/%%VERSION%%"
 
 Conditions:
   DemoData: !Equals [!Ref DemoTemplate, 'Yes']
@@ -106,6 +106,7 @@ Resources:
   # [LogStreamerRole, LogStreamer, LogStreamerInvokePermission, DemoStack]
   #
   LogStreamerRole:
+    DeletionPolicy: 'Retain'
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:
@@ -131,6 +132,11 @@ Resources:
               Action:
               - sts:AssumeRole
               Resource: !Sub ${MasterRole}
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: "The resource access is restricted to lambda functions. The lambda function is generated dynamically during CF execution to provide update flexibility without replacement. Adding the function name dynamically would add cyclic dependency"
 
   LogStreamer:
     Type: AWS::Lambda::Function
@@ -140,20 +146,20 @@ Resources:
         Variables:
           # V56536055 - 10/08/2018 - better logging capabilities
           LOG_LEVEL: 'INFO' #change to WARN, ERROR or DEBUG as needed
-          DomainEndpoint: !Sub ${ESDomain}
-          MasterRole: !Sub ${MasterRole}
-          SessionId: !Sub ${AWS::AccountId}-${AWS::Region}
-          Owner: Spoke
-          Solution: SO0009s
-          ClusterSize: !Ref ClusterSize
+          DOMAIN_ENDPOINT: !Sub ${ESDomain}
+          MASTER_ROLE: !Sub ${MasterRole}
+          SESSION_ID: !Sub ${AWS::AccountId}-${AWS::Region}
+          OWNER: Spoke
+          SOLUTION: SO0009s
+          CLUSTER_SIZE: !Ref ClusterSize
           UUID: !Sub ${CreateUniqueID.UUID}
-          AnonymousData: !FindInMap [InstanceMap, send-data, SendAnonymousData]
+          ANONYMOUS_DATA: !FindInMap [InstanceMap, send-data, SendAnonymousData]
       Handler: index.handler
       Role: !Sub ${LogStreamerRole.Arn}
       Code:
         S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
         S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "clog-indexing-service.zip"]]
-      Runtime: nodejs8.10
+      Runtime: nodejs12.x
       Timeout: 300
 
   LogStreamerInvokePermission:
@@ -172,53 +178,63 @@ Resources:
         LogStreamerArn: !Sub ${LogStreamer.Arn}
         DemoVPCCidr: !Sub ${DemoVPC}
         DemoSubnet: !Sub ${DemoSubnet}
-      TemplateURL: !Join ["/", ["https://s3.amazonaws.com/%%TEMPLATE_BUCKET%%", !FindInMap ["SourceCode", "General", "KeyPrefix"], "centralized-logging-demo.template"]]
+      TemplateURL: !Join 
+        - ''
+        - - 'https://'
+          - !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], "reference"]]
+          - '.s3.amazonaws.com/'
+          - !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "centralized-logging-demo.template"]]
 
   #
   # Solution Helper resources
-  # [SolutionHelperRole, SolutionHelper, SendingAnonymousData, CreateUniqueID]
+  # [CLSolutionHelperRole, CLSolutionHelper, CreateUniqueID]
   #
-  SolutionHelperRole:
+  CLSolutionHelper:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Description: Centralized Logging - Lambda function to generate a unique ID
+      Environment:
+        Variables:
+          # V56536055 - 10/08/2018 - better logging capabilities
+          LOG_LEVEL: 'INFO' #change to WARN, ERROR or DEBUG as needed
+      Handler: index.handler
+      Runtime: nodejs12.x
+      Timeout: 300
+      Role: !GetAtt CLSolutionHelperRole.Arn
+      Code:
+        S3Bucket: !Join ["-", [!FindInMap ["SourceCode", "General", "S3Bucket"], Ref: "AWS::Region"]]
+        S3Key: !Join ["/", [!FindInMap ["SourceCode", "General", "KeyPrefix"],  "clog-auth.zip"]]
+
+  CLSolutionHelperRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: '2012-10-17'
         Statement:
         - Effect: Allow
           Principal:
-            Service: lambda.amazonaws.com
-          Action: sts:AssumeRole
-      Path: /
+            Service:
+            - lambda.amazonaws.com
+          Action:
+          - sts:AssumeRole
+      Path: "/"
       Policies:
-      - PolicyName: Custom_Lambda_Loader_Permissions
+      - PolicyName: root
         PolicyDocument:
-          Version: 2012-10-17
+          Version: '2012-10-17'
           Statement:
           - Effect: Allow
             Action:
             - logs:CreateLogGroup
             - logs:CreateLogStream
             - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
-
-  SolutionHelper:
-    Type: AWS::Lambda::Function
-    Properties:
-      Handler: solution-helper.lambda_handler
-      Role: !Sub ${SolutionHelperRole.Arn}
-      Description: EFS Backup - This function is a CloudFormation custom lambda resource that generates UUID for each deployment.
-      Code:
-       S3Bucket: !Sub solutions-${AWS::Region}
-       S3Key: library/solution-helper/v3/solution-helper.zip
-      Runtime: python2.7
-      Timeout: 300
+            Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${AWS::StackName}-*'
 
   CreateUniqueID:
     Type: Custom::LoadLambda
     Properties:
-      ServiceToken: !Sub ${SolutionHelper.Arn}
-      Region: !Sub ${AWS::Region}
-      CreateUniqueID: true
+      ServiceToken: !GetAtt CLSolutionHelper.Arn
+      Resource: UUID
 
 Outputs:
   LambdaArn:

--- a/deployment/run-unit-tests.sh
+++ b/deployment/run-unit-tests.sh
@@ -1,3 +1,21 @@
-cd ../source/services/indexing
+#!/bin/bash 
+# 
+# This assumes all of the OS-level configuration has been completed and git repo has already been cloned 
+# 
+# This script should be run from the repo's deployment directory 
+# cd deployment 
+# ./run-unit-tests.sh 
+# 
+ 
+# Get reference for all important folders 
+template_dir="$PWD" 
+source_dir="$template_dir/../source" 
+ 
+echo "------------------------------------------------------------------------------" 
+echo "[Test] Services" 
+echo "------------------------------------------------------------------------------" 
+cd $source_dir/services/indexing 
 npm install
-npm test
+npm run build 
+npm test 
+ 

--- a/source/services/auth/index.js
+++ b/source/services/auth/index.js
@@ -1,17 +1,16 @@
 /*******************************************************************************
-* Copyright 2019 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+*  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
 *
-* Licensed under the Amazon Software License (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
+*  Licensed under the Apache License Version 2.0 (the "License"). You may not 
+*  use this file except in compliance with the License. A copy of the License is 
+*  located at                                                           
 *
-*   http://aws.amazon.com/asl/
+*      http://www.apache.org/licenses/
 *
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*
+*  or in the "license" file accompanying this file. This file is distributed on  
+*  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or 
+*  implied. See the License for the specific language governing permissions and  
+*  limitations under the License.      
 ********************************************************************************/
 'use strict';
 /**
@@ -40,38 +39,24 @@ exports.handler = function(event, context) {
           sendResponse(event, context, "SUCCESS", responseData);
         }
         else {
-          //create a domain for a provided Cognito User Pool
+
           let params = {
-              Domain: event.ResourceProperties.CognitoDomain,
-              UserPoolId: event.ResourceProperties.UserPoolId
+              DomainName: event.ResourceProperties.Domain,
+              CognitoOptions: {
+                  Enabled: true,
+                  IdentityPoolId: event.ResourceProperties.IdentityPoolId,
+                  RoleArn: event.ResourceProperties.RoleArn,
+                  UserPoolId: event.ResourceProperties.UserPoolId
+              }
           };
-          cognitoidentityserviceprovider.createUserPoolDomain(params, function(err, data) {
+          es.updateElasticsearchDomainConfig(params, function(err, data) {
               if (err) {
-                  LOGGER.log('ERROR',`error creating domain on Cognito User Pool: ${err.stack}`);
+                  LOGGER.log('ERROR',`error updating the Elasticsearch domain config: ${err.stack}`);
                   sendResponse(event, context, "FAILED", responseData);
               }
               else {
-                  //update the ES domain config for Cognito Auth
-                  LOGGER.log('INFO',"Cognito User Pool Domain Create SUCCEEDED");
-                  let params = {
-                      DomainName: event.ResourceProperties.Domain,
-                      CognitoOptions: {
-                          Enabled: true,
-                          IdentityPoolId: event.ResourceProperties.IdentityPoolId,
-                          RoleArn: event.ResourceProperties.RoleArn,
-                          UserPoolId: event.ResourceProperties.UserPoolId
-                      }
-                  };
-                  es.updateElasticsearchDomainConfig(params, function(err, data) {
-                      if (err) {
-                          LOGGER.log('ERROR',`error updating the Elasticsearch domain config: ${err.stack}`);
-                          sendResponse(event, context, "FAILED", responseData);
-                      }
-                      else {
-                          LOGGER.log('INFO',"Elasticsearch domain config update SUCCEEDED");
-                          sendResponse(event, context, "SUCCESS", responseData);
-                      }
-                  });
+                  LOGGER.log('INFO',"Elasticsearch domain config update SUCCEEDED");
+                  sendResponse(event, context, "SUCCESS", responseData);
               }
           });
 

--- a/source/services/auth/logger.js
+++ b/source/services/auth/logger.js
@@ -1,17 +1,16 @@
 /*******************************************************************************
-* Copyright 2019 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+*  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
 *
-* Licensed under the Amazon Software License (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
+*  Licensed under the Apache License Version 2.0 (the "License"). You may not 
+*  use this file except in compliance with the License. A copy of the License is 
+*  located at                                                           
 *
-*   http://aws.amazon.com/asl/
+*      http://www.apache.org/licenses/
 *
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*
+*  or in the "license" file accompanying this file. This file is distributed on  
+*  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or 
+*  implied. See the License for the specific language governing permissions and  
+*  limitations under the License.      
 ********************************************************************************/
 /**
  * [logger module]

--- a/source/services/indexing/index.js
+++ b/source/services/indexing/index.js
@@ -1,17 +1,16 @@
 /*******************************************************************************
-* Copyright 2019 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+*  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
 *
-* Licensed under the Amazon Software License (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
+*  Licensed under the Apache License Version 2.0 (the "License"). You may not 
+*  use this file except in compliance with the License. A copy of the License is 
+*  located at                                                           
 *
-*   http://aws.amazon.com/asl/
+*      http://www.apache.org/licenses/
 *
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*
+*  or in the "license" file accompanying this file. This file is distributed on  
+*  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or 
+*  implied. See the License for the specific language governing permissions and  
+*  limitations under the License.      
 ********************************************************************************/
 /**
  * @author Solution Builders
@@ -51,7 +50,7 @@ function handler(input, context, callback) {
   LOGGER.log('DEBUG', `Received event: ${eventText}`);
 
   // decode input from base64
-  let zippedInput = new Buffer(input.awslogs.data, 'base64');
+  let zippedInput = new Buffer.from(input.awslogs.data, 'base64');
 
   // decompress the input
   zlib.gunzip(zippedInput, function(error, buffer) {

--- a/source/services/indexing/lib/index.spec.js
+++ b/source/services/indexing/lib/index.spec.js
@@ -1,17 +1,16 @@
 /*******************************************************************************
-* Copyright 2019 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+*  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
 *
-* Licensed under the Amazon Software License (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
+*  Licensed under the Apache License Version 2.0 (the "License"). You may not 
+*  use this file except in compliance with the License. A copy of the License is 
+*  located at                                                           
 *
-*   http://aws.amazon.com/asl/
+*      http://www.apache.org/licenses/
 *
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*
+*  or in the "license" file accompanying this file. This file is distributed on  
+*  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or 
+*  implied. See the License for the specific language governing permissions and  
+*  limitations under the License.      
 ********************************************************************************/
 'use strict';
 

--- a/source/services/indexing/lib/logger.js
+++ b/source/services/indexing/lib/logger.js
@@ -1,17 +1,16 @@
 /*******************************************************************************
-* Copyright 2019 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+*  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
 *
-* Licensed under the Amazon Software License (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
+*  Licensed under the Apache License Version 2.0 (the "License"). You may not 
+*  use this file except in compliance with the License. A copy of the License is 
+*  located at                                                           
 *
-*   http://aws.amazon.com/asl/
+*      http://www.apache.org/licenses/
 *
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*
+*  or in the "license" file accompanying this file. This file is distributed on  
+*  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or 
+*  implied. See the License for the specific language governing permissions and  
+*  limitations under the License.      
 ********************************************************************************/
 /**
  * [logger module]

--- a/source/services/indexing/lib/logger.spec.js
+++ b/source/services/indexing/lib/logger.spec.js
@@ -1,17 +1,16 @@
 /*******************************************************************************
-* Copyright 2019 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+*  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
 *
-* Licensed under the Amazon Software License (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
+*  Licensed under the Apache License Version 2.0 (the "License"). You may not 
+*  use this file except in compliance with the License. A copy of the License is 
+*  located at                                                           
 *
-*   http://aws.amazon.com/asl/
+*      http://www.apache.org/licenses/
 *
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*
+*  or in the "license" file accompanying this file. This file is distributed on  
+*  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or 
+*  implied. See the License for the specific language governing permissions and  
+*  limitations under the License.      
 ********************************************************************************/
 'use strict';
 

--- a/source/services/indexing/lib/metrics-helper.js
+++ b/source/services/indexing/lib/metrics-helper.js
@@ -1,17 +1,16 @@
 /*******************************************************************************
-* Copyright 2019 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+*  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
 *
-* Licensed under the Amazon Software License (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
+*  Licensed under the Apache License Version 2.0 (the "License"). You may not 
+*  use this file except in compliance with the License. A copy of the License is 
+*  located at                                                           
 *
-*   http://aws.amazon.com/asl/
+*      http://www.apache.org/licenses/
 *
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*
+*  or in the "license" file accompanying this file. This file is distributed on  
+*  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or 
+*  implied. See the License for the specific language governing permissions and  
+*  limitations under the License.      
 ********************************************************************************/
 /**
  * @author Solution Builders

--- a/source/services/indexing/lib/test-setup.spec.js
+++ b/source/services/indexing/lib/test-setup.spec.js
@@ -1,17 +1,16 @@
 /*******************************************************************************
-* Copyright 2019 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+*  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
 *
-* Licensed under the Amazon Software License (the "License").
-* You may not use this file except in compliance with the License.
-* A copy of the License is located at
+*  Licensed under the Apache License Version 2.0 (the "License"). You may not 
+*  use this file except in compliance with the License. A copy of the License is 
+*  located at                                                           
 *
-*   http://aws.amazon.com/asl/
+*      http://www.apache.org/licenses/
 *
-* or in the "license" file accompanying this file. This file is distributed
-* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-* express or implied. See the License for the specific language governing
-* permissions and limitations under the License.
-*
+*  or in the "license" file accompanying this file. This file is distributed on  
+*  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or 
+*  implied. See the License for the specific language governing permissions and  
+*  limitations under the License.      
 ********************************************************************************/
 const sinon = require('sinon');
 const chai = require('chai');

--- a/source/services/indexing/package.json
+++ b/source/services/indexing/package.json
@@ -24,7 +24,7 @@
     "https": "*",
     "npm-run-all": "*",
     "stream": "*",
-    "istanbul": "*"
+    "nyc": "*"
   },
   "scripts": {
     "pretest": "npm install",
@@ -34,6 +34,6 @@
     "build:install": "cp package.json dist/ && cd dist && npm install --production",
     "build": "npm-run-all -s build-init build:copy build:install",
     "zip": "cd dist && rm -f package-lock.json && zip -rq clog-indexing-service.zip .",
-    "coverage": "istanbul cover _mocha $(find ./lib -name \"*.spec.js\" -not -path \"./node_modules/*\")"
+    "coverage": "nyc cover _mocha $(find ./lib -name \"*.spec.js\" -not -path \"./node_modules/*\")"
   }
 }


### PR DESCRIPTION
# Change Log
 All notable changes to this project will be documented in this file.

 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## [3.2] - 2019-12-18

### Added
- Backward-compatible to v3.0.0
- Includes all v3.0.1 changes
- Do NOT upgrade from v3.0.1 to v3.2

## [3.0.1] - 2019-11-29

### Added
- Uses SSM Parameters to retrieve the latest HVM x86_64 AMI
- Block public access to 2 buckets created for demo
- CLFullAccessUserRole replaces CognitoAuthorizedRole. It is associated with the Admin group. Initial user is placed in this group.
- CLReadOnlyAccessRole is added. It provides read-only access to users in UserPoolGroupROAccess. This is the default role for Authenticated users in the pool.

### Updated
- Nodejs8.10 to Nodejs12.x Lambda run time.
- Updated license to Apache License version 2.0
- Corrected Master_Role environmental variable in spoke template to MASTER_ROLE
- Updated demo EC2 instance to T3.MICRO
- Updated Nodejs deprecated buffer() to buffer.from()
- Removed python solution-helper from spoke template and replaced with the Nodejs version used by primary.
- Updated NOTICE.txt for 3rd party modules
- Replaced istanbul (deprecated) with nyc
- ElasticSearch version moved to a mapping parameter
- ElasticSearch cluster mappings consolidated under ElasticSearch for clarity/usability
- Tightened security on IAM roles to specific methods and resources

### Removed
- Unreferenced SolutionHelperRole in demo template
- Unreferenced S3 bucket mapping in demo template
- AMIInfo lookup Lambda
- CognitoUnAuthorizedRole / unauthenticated Cognito access